### PR TITLE
DBP-28: 允許在 introspect token 時知道 impersonator

### DIFF
--- a/httpapi/auth/README.md
+++ b/httpapi/auth/README.md
@@ -115,6 +115,16 @@ Authorization: Bearer <access_token>
 }
 ```
 
+如果這是一個代理操作憑證 (impersonation)，則會多出一個 `act` 欄位：
+
+```json
+{
+    "act": {
+        "sub": "2"
+    }
+}
+```
+
 判斷管理員的依據，是判斷 `scope` 是否包含 `*`（所有權限）。
 
 如果沒有此 token，回傳 HTTP 200，且 `active` 為 `false` 的回應：

--- a/httpapi/auth/introspect.go
+++ b/httpapi/auth/introspect.go
@@ -21,6 +21,14 @@ type IntrospectionResponse struct {
 	Exp      int64  `json:"exp,omitempty"`      // expiration time (Unix timestamp)
 	Iat      int64  `json:"iat,omitempty"`      // issued at (Unix timestamp)
 	Azp      string `json:"azp,omitempty"`      // authorized party (machine name)
+
+	// the acting party to whom authority has been delegated
+	Act *IntrospectionAct `json:"act,omitempty"`
+}
+
+// IntrospectionAct represents the acting party to whom authority has been delegated
+type IntrospectionAct struct {
+	Sub string `json:"sub"` // subject (user ID)
 }
 
 // IntrospectToken implements OAuth 2.0 Token Introspection (RFC 7662)
@@ -103,6 +111,12 @@ func (s *AuthService) IntrospectToken(c *gin.Context) {
 		Exp:      exp,
 		Iat:      iat,
 		Azp:      tokenInfo.Machine,
+	}
+
+	if impersonator, ok := tokenInfo.Meta[useraccount.MetaImpersonation]; ok {
+		response.Act = &IntrospectionAct{
+			Sub: impersonator,
+		}
 	}
 
 	c.JSON(http.StatusOK, response)


### PR DESCRIPTION
- **fix(auth): remove useless token sources array**
- **feat(auth): implement "act" field**
